### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,52 @@
-FROM centos:7 as bitrixenv
+# install push-server from bx repo
+FROM centos:7 as push-server
 
-WORKDIR /build
-ADD build.sh /build
-RUN /build/build.sh
+# bitrix repo
+RUN echo $'[bitrix]\n\
+name=$OS $releasever - $basearch\n\
+failovermethod=priority\n\
+baseurl=http://repos.1c-bitrix.ru/yum/el/$releasever/$basearch\n\
+enabled=1\n\
+gpgcheck=1\n\
+gpgkey=http://repos.1c-bitrix.ru/yum/RPM-GPG-KEY-BitrixEnv\n' \
+>> /etc/yum.repos.d/bitrix.repo && \
+# redis repo
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && \
+yum -y install https://rpms.remirepo.net/enterprise/remi-release-7.rpm && \
+# node8 repo
+curl -sL https://rpm.nodesource.com/setup_8.x | sh - && \
+# install
+yum -y update && \
+yum -y install redis-6.0.4 nodejs-8.17.0 bx-push-server-2.0.0 && \
+yum clean all && \
+rm -rf /var/cache/yum
+
+########################################
 
 FROM node:8-alpine
 
-EXPOSE 80
-
 WORKDIR /opt/push-server
 
-COPY --from=bitrixenv /opt/push-server /opt/push-server
+COPY --from=push-server /opt/push-server /opt/push-server
+COPY run.sh /opt/push-server
+COPY config.template.json /etc/push-server/config.template.json
 
+# alpine virtual package
 RUN set -x && \
     apk add --update "libintl" && \
-    apk add --virtual build_deps "gettext" &&  \
+    apk add --virtual build_deps "gettext" &&  \ 
     cp /usr/bin/envsubst /usr/local/bin/envsubst && \
-    apk del build_deps
+    apk del build_deps && \
+    chmod +x /opt/push-server/run.sh
 
-ADD run.sh /opt/push-server
-ADD config.template.json /etc/push-server/
-
+# default env vars
 ENV LISTEN_PORT 8010
 ENV LISTEN_HOSTNAME 0.0.0.0
 ENV REDIS_HOST redis
 ENV REDIS_PORT 6379
-ENV SECURITY_KEY changeme
+ENV SECURITY_KEY IMbEDEnTANDiSPATERSIVeRptUGht
 ENV MODE pub
 
-ENTRYPOINT ["./run.sh"]
+EXPOSE 8010
+
+ENTRYPOINT ["/opt/push-server/run.sh"]


### PR DESCRIPTION
вместо установки bitrix-env, с которым тянутся многие пакеты, устанавливаются только необходимые пакеты для сборки bx-push-server 2.0 по инструкции из оф. статьи установки bx-push-server на стороннем окружении;
поправлен оригинальный Dockerfile: изменены конструкции ADD на COPY, для скрипта run.sh добавлены права на выполнение на случай, если флага +x нет у исходного файла;
изменено значение SECURITY_KEY по умолчанию c "changeme" на более длинную строку.